### PR TITLE
Adding Auto Exchange Support

### DIFF
--- a/config.php
+++ b/config.php
@@ -30,4 +30,6 @@ $fiat = "SET_FIAT_CODE_HERE";
 //Set CRYPTO code if you like (BTC, ETH, etc.)
 $crypto = "SET_CRYPTO_CODE_HERE";
 
+//If Auto Exchanging, set the coin (BTC, ETH, LTC, etc) here
+$ae_coin = "SET_AUTO_EXCHANGE_COIN_HERE"
 ?>

--- a/minerstats.php
+++ b/minerstats.php
@@ -178,11 +178,8 @@ $crypto_decimals = $mph_stats->get_decimal_for_conversion();
 </nav>
 <main role="main" class="container">
     <h1>MiningPoolHub Stats</h1>
-    <h3>24 Hr Earnings: <?php echo $mph_stats->daily_stats() . " " . $fiat; ?></h3>
-
-                            <A target="_blank" HREF="https://<?php echo $worker->coin; ?>.miningpoolhub.com/index.php?page=account&action=workers"><?php echo $worker->username; ?></A>
-                          
-    <h3>Auto Exchanged Balance: <A target="_blank" HREF="https://miningpoolhub.com/?page=account&action=balances">  <?php echo $mph_stats->print_ae_balance(); ?>
+    <h4>24 Hr Earnings: <?php echo $mph_stats->daily_stats(); ?></h3>
+    <h4>Auto Exchanged Balance: <A target="_blank" HREF="https://miningpoolhub.com/?page=account&action=balances">  <?php echo $mph_stats->print_ae_balance(); ?>
     </A></h3>
     <div class="row">
         <div class="col-md-12">

--- a/minerstats.php
+++ b/minerstats.php
@@ -52,7 +52,15 @@ if ($crypto == "SET_CRYPTO_CODE_HERE" || strlen($crypto) >= 5) {
 	$crypto = "ETH";
 }
 
-$mph_stats = new miningpoolhubstats($api_key, $fiat, $crypto);
+//Check to see what we are converting to. Default to BTC
+if ($_GET['ae_coin'] != null) {
+    $ae_coin = filter_var($_GET['ae_coin'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH);
+}
+if ($ae_coin == "SET_AUTO_EXCHANGE_COIN_HERE" || strlen($ae_coin) >= 5) {
+    $ae_coin = null;
+}
+
+$mph_stats = new miningpoolhubstats($api_key, $fiat, $crypto, $ae_coin);
 $crypto_decimals = $mph_stats->get_decimal_for_conversion();
 
 
@@ -171,6 +179,11 @@ $crypto_decimals = $mph_stats->get_decimal_for_conversion();
 <main role="main" class="container">
     <h1>MiningPoolHub Stats</h1>
     <h3>24 Hr Earnings: <?php echo $mph_stats->daily_stats() . " " . $fiat; ?></h3>
+
+                            <A target="_blank" HREF="https://<?php echo $worker->coin; ?>.miningpoolhub.com/index.php?page=account&action=workers"><?php echo $worker->username; ?></A>
+                          
+    <h3>Auto Exchanged Balance: <A target="_blank" HREF="https://miningpoolhub.com/?page=account&action=balances">  <?php echo $mph_stats->print_ae_balance(); ?>
+    </A></h3>
     <div class="row">
         <div class="col-md-12">
             <br><br>
@@ -296,7 +309,7 @@ $crypto_decimals = $mph_stats->get_decimal_for_conversion();
 <footer class="footer">
     <div class="container">
         <span class="text-muted">If you feel like this site has helped you, please consider <a href="#" data-toggle="modal" data-target="#about_donate">donating</a> to help cover server/hosting costs. Thank you!  </span>
-        <span class="text-muted">  &copy; <?php echo date("Y"); ?> Mindbrite LLC.</span>
+        <span class="text-muted">  &copy; <?php date_default_timezone_set('UTC'); echo date("Y"); ?> Mindbrite LLC.</span>
     </div>
 </footer>
 <div class="modal fade" id="about_donate" tabindex="-1" role="dialog" aria-hidden="true">

--- a/miningpoolhubstats.class.php
+++ b/miningpoolhubstats.class.php
@@ -287,8 +287,14 @@ class miningpoolhubstats
 
 	public function daily_stats()
 	{
-		return (number_format($this->payout_last_24_total, $this->get_decimal_for_conversion()));
-
+		$daily_reward = number_format($this->payout_last_24_total, $this->get_decimal_for_conversion());
+		if ($this->ae_coin)
+		{
+			$price = $this->crypto_prices->{$this->ae_coin}->{$this->fiat};
+			return (number_format($this->payout_last_24_total/$price,8) . " " . $this->ae_coin . " (" . $daily_reward . " " . $this->fiat . ")");
+		}
+		else
+			return (($daily_reward) . " " . $this->fiat);
 	}
 
 


### PR DESCRIPTION
I auto convert my Miningpoolhub mining into BTC/LTC/ETH/etc. I noticed that the stats include the autoexchanged coins in a lot of the calculations, so I broke out the auto exchanged coin from the data table. 

Use it like this:

miningpoolhubstats.com/minerstats.php?api_key=....&ae_coin=BTC

You'll see your current auto exchange coin tally and it won't mess up your daily stats. 

Oh, I also added ZClassic coin, it was missing and you often end up mining it when Equihash is profitable.